### PR TITLE
Add docker-compose file

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,9 @@ docker run -p 50001:80 frdel/agent-zero-run
 # Visit http://localhost:50001 to start
 ```
 
-Alternatively, with **docker-ce** and Compose:
+Alternatively, with the Docker Compose plugin:
+
+This compose file requires no `version:` declaration.
 
 ```bash
 docker compose up -d

--- a/README.md
+++ b/README.md
@@ -106,6 +106,15 @@ docker run -p 50001:80 frdel/agent-zero-run
 # Visit http://localhost:50001 to start
 ```
 
+Alternatively, with **docker-ce** and Compose:
+
+```bash
+docker compose up -d
+```
+
+The accompanying `docker-compose.yml` maps `./data` to `/a0` for persistent
+storage and exposes ports `50001` for the Web UI and `55022` for RFC SSH.
+
 ## 🐳 Fully Dockerized, with Speech-to-Text and TTS
 
 ![Settings](docs/res/settings-page-ui.png)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   agent-zero:
     image: frdel/agent-zero-run

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3.8"
+services:
+  agent-zero:
+    image: frdel/agent-zero-run
+    container_name: agent-zero
+    ports:
+      - "50001:80"
+      - "55022:22"
+    volumes:
+      - ./data:/a0
+


### PR DESCRIPTION
## Summary
- add minimal docker-compose file to mirror README quickstart instructions
- extend compose file for docker-ce with volume and RFC port
- document compose usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68423ec2d404832ca47f0bef445c307c